### PR TITLE
skipping job enqueing if ENV variable is set to true

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    test_after_commit (0.4.1)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -138,6 +140,7 @@ DEPENDENCIES
   minitest-spec-rails
   minitest-vcr
   sqlite3
+  test_after_commit
   webmock
 
 BUNDLED WITH

--- a/README.rdoc
+++ b/README.rdoc
@@ -133,6 +133,14 @@ to keep in sync when your model is updated.
     end
   end
 
+If you'd like to turn the syncing off for some reason like when running on a staging server, just set the following ENV variable to true:
+
+SKIP_KINESIS_EVENTS=true
+
+= Versions
+
+0.0.2 - Adding ability to turn off job queueing with ENV variable
+0.0.1 - Initial release
 
 = License
 This project rocks and uses MIT-LICENSE.

--- a/firehose_integration.gemspec
+++ b/firehose_integration.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-spec-rails"
   s.add_development_dependency "minitest-vcr"
   s.add_development_dependency "webmock"
+  s.add_development_dependency "test_after_commit"
 end

--- a/lib/firehose_integration/models/concerns/kinesis_event.rb
+++ b/lib/firehose_integration/models/concerns/kinesis_event.rb
@@ -6,7 +6,7 @@ module FirehoseIntegration
 
     module ClassMethods
       def firehose_integratable
-        after_commit :send_kinesis_event, unless: Proc.new { |instance| instance.try(:skip_kinesis_event) }
+        after_commit :send_kinesis_event, unless: Proc.new { |instance| instance.try(:skip_kinesis_event) || ENV['SKIP_KINESIS_EVENTS'] == 'true' }
 
         begin
           include "#{self.model_name.name}KinesisSerializer".constantize

--- a/lib/firehose_integration/version.rb
+++ b/lib/firehose_integration/version.rb
@@ -1,3 +1,3 @@
 module FirehoseIntegration
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/test/models/concerns/kinesis_event_test.rb
+++ b/test/models/concerns/kinesis_event_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class KinesisEventTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "should raise exception when to_kinesis is not defined" do
     exception = assert_raises(NoMethodError) { StupidModel.new.to_kinesis}
     assert_match "Model must define instance method to_kinesis", exception.message
@@ -23,5 +25,11 @@ class KinesisEventTest < ActiveSupport::TestCase
 
   test 'should prepare an array for redshift' do
     assert_equal "something|1|", DummyModel.new.prepare_for_redshift(["something",1,nil])
+  end
+
+  test 'should not enqueue when SKIP_KINESIS_EVENTS=true' do
+    ENV['SKIP_KINESIS_EVENTS'] = 'true'
+    d = DummyModel.create
+    assert_no_enqueued_jobs
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require "rails/test_help"
 require 'vcr'
 require 'minitest-vcr'
 require 'webmock'
+require 'test_after_commit'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
This skips job enqueing if an ENV variable is set. It will allow people to turn off syncing when they want such as on a staging server.